### PR TITLE
Show shutdown dialog when middle clicking indicator

### DIFF
--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -35,6 +35,7 @@ public class Session.Indicator : Wingpanel.Indicator {
     private Session.Services.UserManager manager;
 
     private Gtk.Grid main_grid;
+    private Session.Widgets.EndSessionDialog? shutdown_dialog = null;
 
     public Indicator (Wingpanel.IndicatorManager.ServerType server_type) {
         Object (code_name: Wingpanel.Indicator.SESSION,
@@ -46,6 +47,15 @@ public class Session.Indicator : Wingpanel.Indicator {
     public override Gtk.Widget get_display_widget () {
         if (indicator_icon == null) {
             indicator_icon = new Wingpanel.Widgets.OverlayIcon (ICON_NAME);
+            indicator_icon.button_press_event.connect ((e) => {
+                if (e.button == Gdk.BUTTON_MIDDLE) {
+                    close ();
+                    show_shutdown_dialog (e.time);
+                    return Gdk.EVENT_STOP;
+                }
+
+                return Gdk.EVENT_PROPAGATE;
+            });
         }
 
         return indicator_icon;
@@ -141,9 +151,7 @@ public class Session.Indicator : Wingpanel.Indicator {
 
         shutdown.clicked.connect (() => {
             close ();
-            var dialog = new Session.Widgets.EndSessionDialog (Session.Widgets.EndSessionDialogType.RESTART);
-            dialog.set_transient_for (indicator_icon.get_toplevel () as Gtk.Window);
-            dialog.show_all ();
+            show_shutdown_dialog ();
         });
 
         suspend.clicked.connect (() => {
@@ -161,6 +169,18 @@ public class Session.Indicator : Wingpanel.Indicator {
     }
 
     public override void closed () {}
+
+    private void show_shutdown_dialog (uint32 timestamp = 0) {
+        if (shutdown_dialog != null) {
+            shutdown_dialog.present ();
+            return;
+        }
+
+        shutdown_dialog = new Session.Widgets.EndSessionDialog (Session.Widgets.EndSessionDialogType.RESTART);
+        shutdown_dialog.destroy.connect (() => { shutdown_dialog = null; });
+        shutdown_dialog.set_transient_for (indicator_icon.get_toplevel () as Gtk.Window);
+        shutdown_dialog.show_all ();
+    }
 }
 
 public Wingpanel.Indicator? get_indicator (Module module, Wingpanel.IndicatorManager.ServerType server_type) {


### PR DESCRIPTION
Fixes #3 
Also fixes a bug that let you open more than one shutdown dialog by clicking the menu item again.

Currently, the dialog doesn't grab focus properly when it's opened by middle-click. This is due to a bug within wingpanel where focus is given back to the wrong window.

A merge request to fix that bug can be found here:
https://code.launchpad.net/~davidmhewitt/wingpanel/fix-focus/+merge/320544