### PR TITLE
Stop fetching users that aren't logged in

### DIFF
--- a/src/Services/DbusInterfaces.vala
+++ b/src/Services/DbusInterfaces.vala
@@ -20,6 +20,7 @@
 struct UserInfo {
     uint32 uid;
     string user_name;
+    ObjectPath? user_object;
 }
 
 /* Power and system control */


### PR DESCRIPTION
Fixes #4 .

The `get_user` method on the logind D-BUS daemon was throwing up a lot of errors about trying to fetch users that didn't exist or weren't logged in.

We can check the status of a user by fetching the list of users and looking in there about the state of each one. This way doesn't fill the console with errors.