### PR TITLE
Check if user is null before using it

### DIFF
--- a/src/Services/UserManager.vala
+++ b/src/Services/UserManager.vala
@@ -166,7 +166,12 @@ public class Session.Services.UserManager : Object {
 
     private Widgets.Userbox? get_userbox_from_user (Act.User user) {
         foreach (Widgets.Userbox userbox in userbox_list) {
-            if (userbox.user.get_user_name () == user.get_user_name ()) {
+            var _user = userbox.user;
+            if (_user == null) {
+                continue;
+            }
+
+            if (_user.get_user_name () == user.get_user_name ()) {
                 return userbox;
             }
         } 

--- a/src/Widgets/UserListBox.vala
+++ b/src/Widgets/UserListBox.vala
@@ -58,7 +58,10 @@
             if (userbox.is_guest) {
                 seat.switch_to_guest ("");
             } else {
-                seat.switch_to_user (userbox.user.get_user_name (), session_path);
+                var user = userbox.user;
+                if (user != null) {
+                    seat.switch_to_user (user.get_user_name (), session_path);
+                }
             }
         } catch (IOError e) {
             stderr.printf ("DisplayManager.Seat error: %s\n", e.message);


### PR DESCRIPTION
The `user` property of `UserBox` is nullable therefore we should check if the `user` is not null before using it. This fixes `[AccountsService] act_user_get_user_name: assertion 'ACT_IS_USER (user)' failed` warnings happening sometimes at initialization.