### PR TITLE
Don't add users in reserved ranges to the list box

### DIFF
--- a/src/Services/UserManager.vala
+++ b/src/Services/UserManager.vala
@@ -160,7 +160,8 @@ public class Session.Services.UserManager : Object {
 
     private void add_user (Act.User user) {
         // Don't add any of the system reserved users
-        if (user.get_uid () < RESERVED_UID_RANGE_END || user.get_uid () == NOBODY_USER_UID) {
+        var uid = user.get_uid ();
+        if (uid < RESERVED_UID_RANGE_END || uid == NOBODY_USER_UID) {
             return;
         }
 

--- a/src/Services/UserManager.vala
+++ b/src/Services/UserManager.vala
@@ -35,6 +35,9 @@ public enum UserState {
 }
 
 public class Session.Services.UserManager : Object {
+    private const uint NOBODY_USER_UID = 65534;
+    private const uint RESERVED_UID_RANGE_END = 1000;
+
     public signal void close ();
 
     private const string LOGIN_IFACE = "org.freedesktop.login1";
@@ -157,7 +160,7 @@ public class Session.Services.UserManager : Object {
 
     private void add_user (Act.User user) {
         // Don't add any of the system reserved users
-        if (user.get_uid () < 1000 || user.get_uid () == 65534) {
+        if (user.get_uid () < RESERVED_UID_RANGE_END || user.get_uid () == NOBODY_USER_UID) {
             return;
         }
 

--- a/src/Services/UserManager.vala
+++ b/src/Services/UserManager.vala
@@ -156,6 +156,11 @@ public class Session.Services.UserManager : Object {
     }
 
     private void add_user (Act.User user) {
+        // Don't add any of the system reserved users
+        if (user.get_uid () < 1000 || user.get_uid () == 65534) {
+            return;
+        }
+
         var userbox = new Session.Widgets.Userbox (user);
         userbox_list.append (userbox);
 


### PR DESCRIPTION
This probably fixes #23 but I don't know since I can't reproduce the issue.

It would be good practice to hide users with this UIDs as these are reserved for system processes. I haven't seen any users with these UIDs be given to the indicator by accountsservice yet, but it's probably a good check to have in place.