### PR TITLE
Remove extra margin from the popover widget

### DIFF
--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -96,7 +96,6 @@ public class Session.Indicator : Wingpanel.Indicator {
 
             main_grid.add (suspend);
             main_grid.add (shutdown);
-            main_grid.margin_top = 6;
 
             connections ();
         }


### PR DESCRIPTION
When making the Nightlight indicator, i noticed that this extra margin was not needed or consistent with the rest of the indicators