### PR TITLE
Fix accounts not showing up when opened

### DIFF
--- a/src/Widgets/UserBox.vala
+++ b/src/Widgets/UserBox.vala
@@ -122,6 +122,7 @@ public class Session.Widgets.Userbox : Gtk.ListBoxRow {
         }
 
         changed ();
+        show_all ();
     }
 
     public override bool draw (Cairo.Context ctx) {


### PR DESCRIPTION
Somehow caused by the comination of https://github.com/elementary/wingpanel/pull/103 and https://github.com/elementary/wingpanel-indicator-session/commit/967de52f54660c4124020cc14d54788861660632

This makes sure that updating the user state by `UserManager` also shows all the new widgets.