### PR TITLE
Fix terminal warning regard Act.User on startup

### DIFF
--- a/src/Services/UserManager.vala
+++ b/src/Services/UserManager.vala
@@ -50,7 +50,7 @@ public class Session.Services.UserManager : Object {
     private Wingpanel.Widgets.Separator users_separator;
 
     public Session.Widgets.UserListBox user_grid;
-    
+
     public bool has_guest { public get; private set; default = false; }
 
     private static SystemInterface? login_proxy;
@@ -60,7 +60,7 @@ public class Session.Services.UserManager : Object {
             login_proxy = Bus.get_proxy_sync (BusType.SYSTEM, LOGIN_IFACE, LOGIN_PATH, DBusProxyFlags.NONE);
         } catch (IOError e) {
             stderr.printf ("UserManager error: %s\n", e.message);
-        }        
+        }
     }
 
     public static UserState get_user_state (uint32 uuid) {
@@ -129,8 +129,8 @@ public class Session.Services.UserManager : Object {
         user_grid.close.connect (() => close ());
 
         manager = Act.UserManager.get_default ();
-        connect_signals ();
         init_users ();
+        connect_signals ();
 
         try {
             dm_proxy = Bus.get_proxy_sync (BusType.SYSTEM, "org.freedesktop.DisplayManager", Environment.get_variable ("XDG_SEAT_PATH"), DBusProxyFlags.NONE);
@@ -149,16 +149,20 @@ public class Session.Services.UserManager : Object {
             if (manager.is_loaded) {
                 init_users ();
             }
-        });  
+        });
     }
 
     private void init_users () {
+        if (!manager.is_loaded) {
+            return;
+        }
+
         foreach (Act.User user in manager.list_users ()) {
             add_user (user);
         }
     }
 
-    private void add_user (Act.User user) {
+    private void add_user (Act.User? user) {
         // Don't add any of the system reserved users
         var uid = user.get_uid ();
         if (uid < RESERVED_UID_RANGE_END || uid == NOBODY_USER_UID) {
@@ -167,9 +171,7 @@ public class Session.Services.UserManager : Object {
 
         var userbox = new Session.Widgets.Userbox (user);
         userbox_list.append (userbox);
-
         user_grid.add (userbox);
-
         users_separator.visible = true;
     }
 
@@ -183,9 +185,9 @@ public class Session.Services.UserManager : Object {
             if (_user.get_user_name () == user.get_user_name ()) {
                 return userbox;
             }
-        } 
+        }
 
-        return null;       
+        return null;
     }
 
     private void remove_user (Act.User user) {

--- a/src/Widgets/UserBox.vala
+++ b/src/Widgets/UserBox.vala
@@ -23,7 +23,7 @@ public class Session.Widgets.Userbox : Gtk.ListBoxRow {
     private const int ICON_SIZE = 48;
 
     public Act.User? user { get; construct; }
-    public bool is_guest { get; set; default = false; }
+    public bool is_guest { get; construct; default = false; }
     public string fullname { get; construct set; }
 
     private Granite.Widgets.Avatar avatar;
@@ -78,11 +78,13 @@ public class Session.Widgets.Userbox : Gtk.ListBoxRow {
 
     // For some reason Act.User.is_logged_in () does not work
     public UserState get_user_state () {
-        if (is_guest) {
-            return Services.UserManager.get_guest_state ();
-        }
+        assert (is_guest || user != null);
 
-        return Services.UserManager.get_user_state (user.get_uid ());
+         if (is_guest) {
+            return Services.UserManager.get_guest_state ();
+        } else {
+            return Services.UserManager.get_user_state (user.get_uid ());
+        }
     }
 
     public bool is_logged_in () {
@@ -131,5 +133,5 @@ public class Session.Widgets.Userbox : Gtk.ListBoxRow {
         }
 
         return base.draw (ctx);
-    }    
+    }
 }

--- a/src/Widgets/UserBox.vala
+++ b/src/Widgets/UserBox.vala
@@ -80,7 +80,7 @@ public class Session.Widgets.Userbox : Gtk.ListBoxRow {
     public UserState get_user_state () {
         assert (is_guest || user != null);
 
-         if (is_guest) {
+        if (is_guest) {
             return Services.UserManager.get_guest_state ();
         } else {
             return Services.UserManager.get_user_state (user.get_uid ());


### PR DESCRIPTION
* Ensure is_guest true when user is null
* Avoid possibly calling init_users () more than once.
* Avoid calling init_users () when manager not loaded.