### PR TITLE
Fix warnings with IOError

### DIFF
--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -158,7 +158,7 @@ public class Session.Indicator : Wingpanel.Indicator {
         lock_screen.clicked.connect (() => {
             try {
                 lock_interface.lock ();
-            } catch (IOError e) {
+            } catch (GLib.Error e) {
                 stderr.printf ("%s\n", e.message);
             }
         });
@@ -176,7 +176,7 @@ public class Session.Indicator : Wingpanel.Indicator {
         suspend.clicked.connect (() => {
             try {
                 suspend_interface.suspend (true);
-            } catch (IOError e) {
+            } catch (GLib.Error e) {
                 stderr.printf ("%s\n", e.message);
             }
         });

--- a/src/Services/UserManager.vala
+++ b/src/Services/UserManager.vala
@@ -87,7 +87,7 @@ public class Session.Services.UserManager : Object {
                 }
             }
 
-        } catch (IOError e) {
+        } catch (GLib.Error e) {
             stderr.printf ("Error: %s\n", e.message);
         }
 
@@ -108,7 +108,7 @@ public class Session.Services.UserManager : Object {
                     return UserState.ACTIVE;
                 }
             }
-        } catch (IOError e) {
+        } catch (GLib.Error e) {
             stderr.printf ("Error: %s\n", e.message);
         }
 

--- a/src/Widgets/EndSessionDialog.vala
+++ b/src/Widgets/EndSessionDialog.vala
@@ -52,7 +52,7 @@ public class Session.Widgets.EndSessionDialog : Gtk.Dialog {
             } else {
                 system_interface = Bus.get_proxy_sync (BusType.SYSTEM, "org.freedesktop.login1", "/org/freedesktop/login1");
             }
-        } catch (IOError e) {
+        } catch (GLib.Error e) {
             stderr.printf ("%s\n", e.message);
         }
 
@@ -109,7 +109,7 @@ public class Session.Widgets.EndSessionDialog : Gtk.Dialog {
             confirm_restart.clicked.connect (() => {
                 try {
                     system_interface.reboot (false);
-                } catch (IOError e) {
+                } catch (GLib.Error e) {
                     stderr.printf ("%s\n", e.message);
                 }
 
@@ -126,13 +126,13 @@ public class Session.Widgets.EndSessionDialog : Gtk.Dialog {
             if (dialog_type == EndSessionDialogType.RESTART || dialog_type == EndSessionDialogType.SHUTDOWN) {
                 try {
                     system_interface.power_off (false);
-                } catch (IOError e) {
+                } catch (GLib.Error e) {
                     stderr.printf ("%s\n", e.message);
                 }
             } else {
                 try {
                     logout_interface.terminate ();
-                } catch (IOError e) {
+                } catch (GLib.Error e) {
                     stderr.printf ("%s\n", e.message);
                 }
                 destroy ();

--- a/src/Widgets/UserListBox.vala
+++ b/src/Widgets/UserListBox.vala
@@ -63,7 +63,7 @@
                     seat.switch_to_user (user.get_user_name (), session_path);
                 }
             }
-        } catch (IOError e) {
+        } catch (GLib.Error e) {
             stderr.printf ("DisplayManager.Seat error: %s\n", e.message);
         }
     }


### PR DESCRIPTION
Replace IOError with GLib.Error to fix warnings about uncaught errors