### PR TITLE
Show the users when opening the indicator first time

### DIFF
--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -185,6 +185,7 @@ public class Session.Indicator : Wingpanel.Indicator {
 
     public override void opened () {
         manager.update_all ();
+        main_grid.show_all ();
     }
 
     public override void closed () {}


### PR DESCRIPTION
When opening the indicator for the first time we didn't call `show_all` on the main grid and it didn't display any users upon re-opening the indicator. This change makes it so it works always.