### PR TITLE
EndSessionDialog interface implementation

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -20,6 +20,7 @@ shared_module(
     'src/Widgets/UserListBox.vala',
     'src/Services/DbusInterfaces.vala',
     'src/Services/UserManager.vala',
+    'src/Services/EndSessionDialogServer.vala',
     dependencies: [
         dependency('accountsservice'),
         dependency('glib-2.0'),

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -46,10 +46,8 @@ public class Session.Indicator : Wingpanel.Indicator {
         this.server_type = server_type;
         this.visible = true;
 
-        if (server_type == Wingpanel.IndicatorManager.ServerType.SESSION) {
-            EndSessionDialogServer.init ();
-            EndSessionDialogServer.get_default ().show_dialog.connect ((type) => show_dialog ((Widgets.EndSessionDialogType)type));
-        }
+        EndSessionDialogServer.init ();
+        EndSessionDialogServer.get_default ().show_dialog.connect ((type) => show_dialog ((Widgets.EndSessionDialogType)type));
     }
 
     public override Gtk.Widget get_display_widget () {

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -192,13 +192,15 @@ public class Session.Indicator : Wingpanel.Indicator {
         if (current_dialog != null) {
             if (current_dialog.dialog_type != type) {
                 current_dialog.destroy ();
+            } else {
+                return;
             }
-        } else {
-            current_dialog = new Widgets.EndSessionDialog (type);
-            current_dialog.destroy.connect (() => current_dialog = null);
-            current_dialog.set_transient_for (indicator_icon.get_toplevel () as Gtk.Window);
-            current_dialog.show_all ();
         }
+        
+        current_dialog = new Widgets.EndSessionDialog (type);
+        current_dialog.destroy.connect (() => current_dialog = null);
+        current_dialog.set_transient_for (indicator_icon.get_toplevel () as Gtk.Window);
+        current_dialog.show_all ();
     }
 }
 

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -37,7 +37,6 @@ public class Session.Indicator : Wingpanel.Indicator {
     private Session.Services.UserManager manager;
 
     private Gtk.Grid main_grid;
-    private Session.Widgets.EndSessionDialog? shutdown_dialog = null;
 
     public Indicator (Wingpanel.IndicatorManager.ServerType server_type) {
         Object (code_name: Wingpanel.Indicator.SESSION,
@@ -45,6 +44,9 @@ public class Session.Indicator : Wingpanel.Indicator {
                 description: _("The session indicator"));
         this.server_type = server_type;
         this.visible = true;
+
+        EndSessionDialogServer.init ();
+        EndSessionDialogServer.get_default ().show_dialog.connect (show_dialog);
     }
 
     public override Gtk.Widget get_display_widget () {
@@ -53,7 +55,7 @@ public class Session.Indicator : Wingpanel.Indicator {
             indicator_icon.button_press_event.connect ((e) => {
                 if (e.button == Gdk.BUTTON_MIDDLE) {
                     close ();
-                    show_shutdown_dialog ();
+                    show_dialog (Widgets.EndSessionDialogType.RESTART);
                     return Gdk.EVENT_STOP;
                 }
 
@@ -164,15 +166,8 @@ public class Session.Indicator : Wingpanel.Indicator {
             }
         });
 
-        log_out.clicked.connect (() => {
-            var dialog = new Session.Widgets.EndSessionDialog (Session.Widgets.EndSessionDialogType.LOGOUT);
-            dialog.set_transient_for (indicator_icon.get_toplevel () as Gtk.Window);
-            dialog.show_all ();
-        });
-
-        shutdown.clicked.connect (() => {
-            show_shutdown_dialog ();
-        });
+        log_out.clicked.connect (() => show_dialog (Widgets.EndSessionDialogType.LOGOUT));
+        shutdown.clicked.connect (() => show_dialog (Widgets.EndSessionDialogType.RESTART));
 
         suspend.clicked.connect (() => {
             try {
@@ -190,15 +185,10 @@ public class Session.Indicator : Wingpanel.Indicator {
 
     public override void closed () {}
 
-    private void show_shutdown_dialog () {
-        if (shutdown_dialog == null) {
-            shutdown_dialog = new Session.Widgets.EndSessionDialog (Session.Widgets.EndSessionDialogType.RESTART);
-            shutdown_dialog.destroy.connect (() => { shutdown_dialog = null; });
-            shutdown_dialog.set_transient_for (indicator_icon.get_toplevel () as Gtk.Window);
-            shutdown_dialog.show_all ();
-        }
-
-        shutdown_dialog.present ();
+    private void show_dialog (uint type) {
+        var dialog = new Widgets.EndSessionDialog ((Widgets.EndSessionDialogType)type);
+        dialog.set_transient_for (indicator_icon.get_toplevel () as Gtk.Window);
+        dialog.show_all ();
     }
 }
 

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -45,8 +45,10 @@ public class Session.Indicator : Wingpanel.Indicator {
         this.server_type = server_type;
         this.visible = true;
 
-        EndSessionDialogServer.init ();
-        EndSessionDialogServer.get_default ().show_dialog.connect (show_dialog);
+        if (server_type == Wingpanel.IndicatorManager.ServerType.SESSION) {
+            EndSessionDialogServer.init ();
+            EndSessionDialogServer.get_default ().show_dialog.connect (show_dialog);
+        }
     }
 
     public override Gtk.Widget get_display_widget () {

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -35,6 +35,7 @@ public class Session.Indicator : Wingpanel.Indicator {
     private Gtk.ModelButton shutdown;
 
     private Session.Services.UserManager manager;
+    private Widgets.EndSessionDialog? current_dialog = null;
 
     private Gtk.Grid main_grid;
 
@@ -47,7 +48,7 @@ public class Session.Indicator : Wingpanel.Indicator {
 
         if (server_type == Wingpanel.IndicatorManager.ServerType.SESSION) {
             EndSessionDialogServer.init ();
-            EndSessionDialogServer.get_default ().show_dialog.connect (show_dialog);
+            EndSessionDialogServer.get_default ().show_dialog.connect ((type) => show_dialog ((Widgets.EndSessionDialogType)type));
         }
     }
 
@@ -187,10 +188,17 @@ public class Session.Indicator : Wingpanel.Indicator {
 
     public override void closed () {}
 
-    private void show_dialog (uint type) {
-        var dialog = new Widgets.EndSessionDialog ((Widgets.EndSessionDialogType)type);
-        dialog.set_transient_for (indicator_icon.get_toplevel () as Gtk.Window);
-        dialog.show_all ();
+    private void show_dialog (Widgets.EndSessionDialogType type) {
+        if (current_dialog != null) {
+            if (current_dialog.dialog_type != type) {
+                current_dialog.destroy ();
+            }
+        } else {
+            current_dialog = new Widgets.EndSessionDialog (type);
+            current_dialog.destroy.connect (() => current_dialog = null);
+            current_dialog.set_transient_for (indicator_icon.get_toplevel () as Gtk.Window);
+            current_dialog.show_all ();
+        }
     }
 }
 

--- a/src/Services/EndSessionDialogServer.vala
+++ b/src/Services/EndSessionDialogServer.vala
@@ -17,16 +17,16 @@
  * Boston, MA 02110-1301 USA
  */
 
-[DBus (name = "io.elementary.wingpanel.session.enddialog")]
+[DBus (name = "io.elementary.wingpanel.session.EndSessionDialog")]
 public class Session.EndSessionDialogServer : Object {
     private static EndSessionDialogServer? instance;
 
     [DBus (visible = false)]
     public static void init () {
-        Bus.own_name (BusType.SESSION, "io.elementary.wingpanel.session.enddialog", BusNameOwnerFlags.NONE,
+        Bus.own_name (BusType.SESSION, "io.elementary.wingpanel.session.EndSessionDialog", BusNameOwnerFlags.NONE,
             (connection) => {
                 try {
-                    connection.register_object ("/io/elementary/wingpanel/session/enddialog", get_default ());
+                    connection.register_object ("/io/elementary/wingpanel/session/EndSessionDialog", get_default ());
                 } catch (Error e) { 
                     warning (e.message); 
                 }

--- a/src/Services/EndSessionDialogServer.vala
+++ b/src/Services/EndSessionDialogServer.vala
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2011-2018 elementary LLC. (http://launchpad.net/wingpanel)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA
+ */
+
+[DBus (name = "io.elementary.wingpanel.session.enddialog")]
+public class Session.EndSessionDialogServer : Object {
+    private static EndSessionDialogServer? instance;
+
+    [DBus (visible = false)]
+    public static void init () {
+        Bus.own_name (BusType.SESSION, "io.elementary.wingpanel.session.enddialog", BusNameOwnerFlags.NONE,
+            (connection) => {
+                try {
+                    connection.register_object ("/io/elementary/wingpanel/session/enddialog", get_default ());
+                } catch (Error e) { 
+                    warning (e.message); 
+                }
+            },
+            () => {},
+            () => warning ("Could not acquire name"));
+    }
+
+    public static unowned EndSessionDialogServer get_default () {
+        if (instance == null) {
+            instance = new EndSessionDialogServer ();
+        }
+
+        return instance;
+    }
+
+    [DBus (visible = false)]
+    public signal void show_dialog (uint type);
+
+    public signal void confirmed_logout ();
+    public signal void confirmed_reboot ();
+    public signal void confirmed_shutdown ();
+    public signal void canceled ();
+    public signal void closed ();
+
+    private EndSessionDialogServer () {
+        
+    }
+
+
+    public void open (uint type, uint timestamp, uint open_length, ObjectPath[] inhibiters) throws Error {
+        if (type > (int)Widgets.EndSessionDialogType.RESTART) {
+            throw new DBusError.NOT_SUPPORTED ("Hibernate, suspend and hybrid sleep are not supported actions yet");
+        }
+
+        show_dialog (type);
+    }
+}

--- a/src/Widgets/EndSessionDialog.vala
+++ b/src/Widgets/EndSessionDialog.vala
@@ -28,8 +28,8 @@ public enum Session.Widgets.EndSessionDialogType {
 }
 
 public class Session.Widgets.EndSessionDialog : Gtk.Dialog {
-    private static LogoutInterface logout_interface;
-    private static SystemInterface system_interface;
+    private static LogoutInterface? logout_interface;
+    private static SystemInterface? system_interface;
 
     public EndSessionDialogType dialog_type { get; construct; }
 


### PR DESCRIPTION
Goes with https://github.com/elementary/gala/pull/314.
This partially *solves* #57.

This doesn't actually implement `org.gnome.SessionManager.EndSessionDialog` because that will be implemented in gala itself so that all interfaces of `org.gnome.SessionManager` are owned by gala.

Gala will just own the GNOME EndSessionDialog interface and forward the calls from it to this interface.
(If you don't agree on this, please comment)

There are some code changes to streamline the server and indicator functions and remove some unneded initializations that happened before. The interface is not registered when not in session mode.

