### PR TITLE
Allow running without a display manager

### DIFF
--- a/src/Services/UserManager.vala
+++ b/src/Services/UserManager.vala
@@ -40,13 +40,14 @@ public class Session.Services.UserManager : Object {
 
     public signal void close ();
 
+    private const string DM_DBUS_ID = "org.freedesktop.DisplayManager";
     private const string LOGIN_IFACE = "org.freedesktop.login1";
     private const string LOGIN_PATH = "/org/freedesktop/login1";
 
     private signal void delete_user (ObjectPath user_path);
     private Act.UserManager manager;
     private List<Widgets.Userbox> userbox_list;
-    private SeatInterface dm_proxy;
+    private SeatInterface? dm_proxy = null;
     private Wingpanel.Widgets.Separator users_separator;
 
     public Session.Widgets.UserListBox user_grid;
@@ -132,11 +133,15 @@ public class Session.Services.UserManager : Object {
         init_users ();
         connect_signals ();
 
-        try {
-            dm_proxy = Bus.get_proxy_sync (BusType.SYSTEM, "org.freedesktop.DisplayManager", Environment.get_variable ("XDG_SEAT_PATH"), DBusProxyFlags.NONE);
-            has_guest = dm_proxy.has_guest_account;
-        } catch (IOError e) {
-            stderr.printf ("UserManager error: %s\n", e.message);
+        var seat_path = Environment.get_variable ("XDG_SEAT_PATH");
+
+        if (seat_path != null) {
+            try {
+                dm_proxy = Bus.get_proxy_sync (BusType.SYSTEM, DM_DBUS_ID, seat_path, DBusProxyFlags.NONE);
+                has_guest = dm_proxy.has_guest_account;
+            } catch (IOError e) {
+                stderr.printf ("UserManager error: %s\n", e.message);
+            }
         }
     }
 

--- a/src/Widgets/UserListBox.vala
+++ b/src/Widgets/UserListBox.vala
@@ -24,14 +24,19 @@
     private string session_path;
     private bool has_guest;
 
+    private const string DM_DBUS_ID = "org.freedesktop.DisplayManager";
+
     public UserListBox () {
         has_guest = false;
         session_path = Environment.get_variable ("XDG_SESSION_PATH");
 
-        try {
-            seat = Bus.get_proxy_sync (BusType.SYSTEM, "org.freedesktop.DisplayManager", Environment.get_variable ("XDG_SEAT_PATH"), DBusProxyFlags.NONE);
-        } catch (IOError e) {
-            stderr.printf ("DisplayManager.Seat error: %s\n", e.message);
+        var seat_path = Environment.get_variable ("XDG_SEAT_PATH");
+        if (seat_path != null) {
+            try {
+                seat = Bus.get_proxy_sync (BusType.SYSTEM, DM_DBUS_ID, seat_path, DBusProxyFlags.NONE);
+            } catch (IOError e) {
+                stderr.printf ("DisplayManager.Seat error: %s\n", e.message);
+            }
         }
 
         this.set_sort_func (sort_func);
@@ -47,7 +52,7 @@
 
     public override void row_activated (Gtk.ListBoxRow row) {
         var userbox = (Userbox)row;
-        if (userbox == null 
+        if (userbox == null
             || seat == null
             || session_path == "") {
             return;


### PR DESCRIPTION
Fixes #64 

`XDG_SEAT_PATH` only exists if the DE has been launched via something that sets it (e.g. lightdm).

With my experiment of logging in via VNC, I don't go via the display manager and instead launch a session directly on VNC login and hence don't have this env var set.

Passing a null path to `get_proxy_sync` causes an assertion that crashes wingpanel. So while this doesn't change the behaviour at all for normal use, it makes it way less crashy for nonstandard display managers or weird remote logins like mine.