### PR TITLE
EndSessionDialog: Subclass Gtk.Window

### DIFF
--- a/src/Widgets/EndSessionDialog.vala
+++ b/src/Widgets/EndSessionDialog.vala
@@ -143,7 +143,7 @@ public class Session.Widgets.EndSessionDialog : Gtk.Window {
         type_hint = Gdk.WindowTypeHint.DIALOG;
         get_style_context ().add_class ("rounded");
         set_keep_above (true);
-        set_position (Gtk.WindowPosition.CENTER_ALWAYS);
+        set_position (Gtk.WindowPosition.CENTER);
         set_titlebar (titlebar);
         stick ();
         add (grid);

--- a/src/Widgets/EndSessionDialog.vala
+++ b/src/Widgets/EndSessionDialog.vala
@@ -91,8 +91,6 @@ public class Session.Widgets.EndSessionDialog : Gtk.Window {
         var confirm = new Gtk.Button.with_label (button_text);
         confirm.get_style_context ().add_class (Gtk.STYLE_CLASS_DESTRUCTIVE_ACTION);
 
-        set_default (confirm);
-
         var action_area = new Gtk.ButtonBox (Gtk.Orientation.HORIZONTAL);
         action_area.layout_style = Gtk.ButtonBoxStyle.END;
         action_area.margin_top = 16;
@@ -147,6 +145,8 @@ public class Session.Widgets.EndSessionDialog : Gtk.Window {
         set_titlebar (titlebar);
         stick ();
         add (grid);
+
+        cancel.grab_focus ();
 
         cancel.clicked.connect (() => { 
             server.canceled ();

--- a/src/Widgets/EndSessionDialog.vala
+++ b/src/Widgets/EndSessionDialog.vala
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2011-2015 Tom Beckmann
+ * Copyright 2019 elementary, Inc (https://elementary.io)
+ *           2011-2015 Tom Beckmann
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public
@@ -27,22 +28,14 @@ public enum Session.Widgets.EndSessionDialogType {
     RESTART = 2
 }
 
-public class Session.Widgets.EndSessionDialog : Gtk.Dialog {
+public class Session.Widgets.EndSessionDialog : Gtk.Window {
     private static LogoutInterface? logout_interface;
     private static SystemInterface? system_interface;
 
     public EndSessionDialogType dialog_type { get; construct; }
 
     public EndSessionDialog (Session.Widgets.EndSessionDialogType type) {
-        Object (
-            dialog_type: type,
-            title: "",
-            deletable: false,
-            resizable: false,
-            skip_taskbar_hint: true,
-            skip_pager_hint: true,
-            type_hint: Gdk.WindowTypeHint.DIALOG
-        );
+        Object (dialog_type: type);
     }
 
     construct {
@@ -79,27 +72,31 @@ public class Session.Widgets.EndSessionDialog : Gtk.Dialog {
                 break;
         }
 
-        set_position (Gtk.WindowPosition.CENTER_ALWAYS);
-        set_keep_above (true);
-        stick ();
-
         var image = new Gtk.Image.from_icon_name (icon_name, Gtk.IconSize.DIALOG);
         image.valign = Gtk.Align.START;
 
-        var heading = new Gtk.Label (heading_text);
-        heading.get_style_context ().add_class (Granite.STYLE_CLASS_PRIMARY_LABEL);
-        heading.xalign = 0;
+        var primary_label = new Gtk.Label (heading_text);
+        primary_label.get_style_context ().add_class (Granite.STYLE_CLASS_PRIMARY_LABEL);
+        primary_label.max_width_chars = 50;
+        primary_label.wrap = true;
+        primary_label.xalign = 0;
 
         var secondary_label = new Gtk.Label (content_text);
+        secondary_label.max_width_chars = 50;
+        secondary_label.wrap = true;
         secondary_label.xalign = 0;
 
-        var grid = new Gtk.Grid ();
-        grid.column_spacing = 12;
-        grid.row_spacing = 6;
-        grid.margin_start = grid.margin_end = grid.margin_bottom = 12;
-        grid.attach (image, 0, 0, 1, 2);
-        grid.attach (heading, 1, 0, 1, 1);
-        grid.attach (secondary_label, 1, 1, 1, 1);
+        var cancel = new Gtk.Button.with_label (_("Cancel"));
+
+        var confirm = new Gtk.Button.with_label (button_text);
+        confirm.get_style_context ().add_class (Gtk.STYLE_CLASS_DESTRUCTIVE_ACTION);
+
+        set_default (confirm);
+
+        var action_area = new Gtk.ButtonBox (Gtk.Orientation.HORIZONTAL);
+        action_area.layout_style = Gtk.ButtonBoxStyle.END;
+        action_area.margin_top = 16;
+        action_area.spacing = 6;
 
         /*
          * the indicator does not have a separate item for restart, that's
@@ -107,7 +104,7 @@ public class Session.Widgets.EndSessionDialog : Gtk.Dialog {
          * (which is sent for shutdown as described above)
          */
         if (dialog_type == EndSessionDialogType.RESTART) {
-            var confirm_restart = add_button (_("Restart"), Gtk.ResponseType.OK) as Gtk.Button;
+            var confirm_restart = new Gtk.Button.with_label (_("Restart"));
             confirm_restart.clicked.connect (() => {
                 try {
                     server.confirmed_reboot ();
@@ -119,17 +116,44 @@ public class Session.Widgets.EndSessionDialog : Gtk.Dialog {
                 server.closed ();
                 destroy ();
             });
+
+            action_area.add (confirm_restart);
         }
 
-        var cancel = add_button (_("Cancel"), Gtk.ResponseType.CANCEL) as Gtk.Button;
+        action_area.add (cancel);
+        action_area.add (confirm);
+
+        var grid = new Gtk.Grid ();
+        grid.column_spacing = 12;
+        grid.margin = 12;
+        grid.margin_top = 6;
+        grid.attach (image, 0, 0, 1, 2);
+        grid.attach (primary_label, 1, 0);
+        grid.attach (secondary_label, 1, 1);
+        grid.attach (action_area, 0, 2, 2);
+
+        var titlebar = new Gtk.HeaderBar ();
+        titlebar.custom_title = new Gtk.Grid ();
+        titlebar.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
+
+        deletable = false;
+        resizable = false;
+        skip_taskbar_hint = true;
+        skip_pager_hint = true;
+        type_hint = Gdk.WindowTypeHint.DIALOG;
+        get_style_context ().add_class ("rounded");
+        set_keep_above (true);
+        set_position (Gtk.WindowPosition.CENTER_ALWAYS);
+        set_titlebar (titlebar);
+        stick ();
+        add (grid);
+
         cancel.clicked.connect (() => { 
             server.canceled ();
             server.closed ();
             destroy ();
         });
 
-        var confirm = add_button (button_text, Gtk.ResponseType.OK) as Gtk.Button;
-        confirm.get_style_context ().add_class ("destructive-action");
         confirm.clicked.connect (() => {
             if (dialog_type == EndSessionDialogType.RESTART || dialog_type == EndSessionDialogType.SHUTDOWN) {
                 try {
@@ -150,12 +174,5 @@ public class Session.Widgets.EndSessionDialog : Gtk.Dialog {
             server.closed ();
             destroy ();
         });
-
-        set_default (confirm);
-
-        get_content_area ().add (grid);
-
-        var action_area = get_action_area ();
-        action_area.margin = 6;
     }
 }


### PR DESCRIPTION
Works around the unstyled titlebar in the greeter session