### PR TITLE
Focus confirm instead of cancel.

### DIFF
--- a/src/Widgets/EndSessionDialog.vala
+++ b/src/Widgets/EndSessionDialog.vala
@@ -147,8 +147,6 @@ public class Session.Widgets.EndSessionDialog : Gtk.Window {
         stick ();
         add (grid);
 
-        cancel.grab_focus ();
-
         var cancel_action = new SimpleAction ("cancel", null);
         cancel_action.activate.connect (() => {
             server.canceled ();
@@ -167,6 +165,8 @@ public class Session.Widgets.EndSessionDialog : Gtk.Window {
 
             return false;
         });
+
+        confirm.grab_focus ();
 
         confirm.clicked.connect (() => {
             if (dialog_type == EndSessionDialogType.RESTART || dialog_type == EndSessionDialogType.SHUTDOWN) {


### PR DESCRIPTION
Hey, 

I think it would be reasonable to directly focus the confirm button in the Shutdown/Logout dialog of the session-indicator. This would make it possible to shutdown/logout the computer with two clicks: Three-finger/middle-click to bring up the dialog and <kbd>enter/space</kbd> to confirm.

I understand this would make it more likely to shutdown the computer accidentally, but I think it is still very unlikely to open the dialog and click <kbd>enter/space</kbd> by accident. I think therefore it is worth the risk to make the shutdown action more accessible.

If there is another critical reason to make `cancel` the default action which I overlook, feel free to just dismiss this PR.

Problems:
With the current style, It is not obvious that the shutdown button is selected. So a style change would also be needed

**Before:**
![beforechanges](https://user-images.githubusercontent.com/39961576/64736968-20d96800-d4ec-11e9-8fb7-c7460429fbad.png)

**After:**
![afterchanges](https://user-images.githubusercontent.com/39961576/64736967-20d96800-d4ec-11e9-93e6-dc8c1d3f405b.png)