### PR TITLE
Don't trigger updating users list in Greeter

### DIFF
--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -204,7 +204,10 @@ public class Session.Indicator : Wingpanel.Indicator {
     }
 
     public override void opened () {
-        manager.update_all ();
+        if (server_type == Wingpanel.IndicatorManager.ServerType.SESSION) {
+            manager.update_all ();
+        }
+
         main_grid.show_all ();
     }
 


### PR DESCRIPTION
Fix the following error message is shown in Greeter

```
** (wingpanel:24861): CRITICAL **: 22:33:08.069: session_services_user_manager_update_all: assertion 'self != NULL' failed
```

Test by running `wingpanel -g`
