### PR TITLE
UserListBox: Remove unnecessary add method

### DIFF
--- a/src/Services/UserManager.vala
+++ b/src/Services/UserManager.vala
@@ -220,7 +220,7 @@ public class Session.Services.UserManager : Object {
         userbox_list.append (userbox);
         userbox.visible = true;
 
-        user_grid.add_guest (userbox);
+        user_grid.add (userbox);
 
         users_separator.visible = true;
     }

--- a/src/Widgets/UserListBox.vala
+++ b/src/Widgets/UserListBox.vala
@@ -22,12 +22,10 @@
 
     private SeatInterface? seat = null;
     private string session_path;
-    private bool has_guest;
 
     private const string DM_DBUS_ID = "org.freedesktop.DisplayManager";
 
     public UserListBox () {
-        has_guest = false;
         session_path = Environment.get_variable ("XDG_SESSION_PATH");
 
         var seat_path = Environment.get_variable ("XDG_SEAT_PATH");
@@ -41,13 +39,6 @@
 
         this.set_sort_func (sort_func);
         this.set_activate_on_single_click (true);
-    }
-
-    public void add_guest (Userbox user) {
-        if (!has_guest) {
-            this.add (user);
-            has_guest = true;
-        }
     }
 
     public override void row_activated (Gtk.ListBoxRow row) {


### PR DESCRIPTION
This is only ever done when UserManager is constructed, so why are we guarding against multiple adds?