### PR TITLE
Use Seat interface to lock session

### DIFF
--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -22,7 +22,6 @@ public class Session.Indicator : Wingpanel.Indicator {
     private const string KEYBINDING_SCHEMA = "org.gnome.settings-daemon.plugins.media-keys";
 
     private SystemInterface suspend_interface;
-    private LockInterface lock_interface;
 
     private Wingpanel.IndicatorManager.ServerType server_type;
     private Wingpanel.Widgets.OverlayIcon indicator_icon;
@@ -157,7 +156,7 @@ public class Session.Indicator : Wingpanel.Indicator {
                 close ();
 
                 try {
-                    lock_interface.lock ();
+                    Session.Services.UserManager.lock ();
                 } catch (GLib.Error e) {
                     warning ("Unable to lock: %s", e.message);
                 }
@@ -175,13 +174,8 @@ public class Session.Indicator : Wingpanel.Indicator {
             suspend.set_sensitive (false);
         }
 
-        if (server_type == Wingpanel.IndicatorManager.ServerType.SESSION) {
-            try {
-                lock_interface = Bus.get_proxy_sync (BusType.SESSION, "org.freedesktop.ScreenSaver", "/org/freedesktop/ScreenSaver");
-            } catch (IOError e) {
-                warning ("Unable to connect to lock interface: %s", e.message);
-                lock_screen.set_sensitive (false);
-            }
+        if (server_type != Wingpanel.IndicatorManager.ServerType.SESSION) {
+            lock_screen.set_sensitive (false);
         }
     }
 

--- a/src/Services/DbusInterfaces.vala
+++ b/src/Services/DbusInterfaces.vala
@@ -23,12 +23,6 @@ struct UserInfo {
     ObjectPath? user_object;
 }
 
-/* Power and system control */
-[DBus (name = "org.freedesktop.ScreenSaver")]
-interface LockInterface : Object {
-    public abstract void lock () throws GLib.Error;
-}
-
 [DBus (name = "org.freedesktop.login1.User")]
 interface LogoutInterface : Object {
     public abstract void terminate () throws GLib.Error;
@@ -53,4 +47,5 @@ interface SeatInterface : Object {
     public abstract bool has_guest_account { get; }
     public abstract void switch_to_guest (string session_name) throws GLib.Error;
     public abstract void switch_to_user (string username, string session_name) throws GLib.Error;
+    public abstract void lock () throws GLib.Error;
 }


### PR DESCRIPTION
This switches the DBus interface used to lock the session from `org.gnome.ScreenSaver` to `org.freedesktop.DisplayManager.Seat`.

This only affects clicking the "Lock" option in the menu and does not affect the behaviour of locking because of inactivity timeout, locking on lid close, or locking because of `<Super><L>`

Seems to resolve the issue described in https://github.com/elementary/greeter/issues/437#issuecomment-629704034 (obviously when locking using the menu option, other methods of locking are still broken as described from my testing).

Will need testing for any other locking related regressions.