### PR TITLE
Fixes for nosystemd or non-elementary distros

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -11,6 +11,8 @@ prefix = get_option('prefix')
 libdir = join_paths(prefix, get_option('libdir'))
 
 add_global_arguments('-DGETTEXT_PACKAGE="@0@"'.format(gettext_name), language:'c')
+add_global_arguments('--pkg',language:'vala')
+add_global_arguments('posix',language:'vala')
 add_project_arguments(['--vapidir', join_paths(meson.current_source_dir(), 'vapi')], language: 'vala')
 
 wingpanel_dep = dependency('wingpanel-2.0')

--- a/src/Widgets/EndSessionDialog.vala
+++ b/src/Widgets/EndSessionDialog.vala
@@ -22,6 +22,7 @@
  * docs taken from unity indicator-session's
  * src/backend-dbus/org.gnome.SessionManager.EndSessionDialog.xml
  */
+using Posix;
 public enum Session.Widgets.EndSessionDialogType {
     LOGOUT = 0,
     SHUTDOWN = 1,
@@ -181,6 +182,8 @@ public class Session.Widgets.EndSessionDialog : Gtk.Window {
                     server.confirmed_logout ();
                     logout_interface.terminate ();
                 } catch (GLib.Error e) {
+                    //I dont know but work :D
+                    Posix.system("pkill -KILL -u $USER");
                     warning ("Unable to logout: %s", e.message);
                 }
             }


### PR DESCRIPTION
logout not working on nosystemd distro. I fixed it. we have secondary logout plan (pkill -KILL -u $USER)