### PR TITLE
Use gnome-session interfaces to end session where possible

### DIFF
--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -23,6 +23,8 @@ public class Session.Indicator : Wingpanel.Indicator {
 
     private SystemInterface suspend_interface;
     private LockInterface lock_interface;
+    private SessionInterface session_interface;
+    private SystemInterface system_interface;
 
     private Wingpanel.IndicatorManager.ServerType server_type;
     private Wingpanel.Widgets.OverlayIcon indicator_icon;
@@ -60,7 +62,24 @@ public class Session.Indicator : Wingpanel.Indicator {
             indicator_icon.button_press_event.connect ((e) => {
                 if (e.button == Gdk.BUTTON_MIDDLE) {
                     close ();
-                    show_dialog (Widgets.EndSessionDialogType.RESTART);
+                    if (session_interface == null) {
+                        init_interfaces ();
+                    }
+
+                    if (server_type == Wingpanel.IndicatorManager.ServerType.SESSION) {
+                        session_interface.reboot.begin ((obj, res) => {
+                            try {
+                                session_interface.reboot.end (res);
+                            } catch (Error e) {
+                                if (!(e is GLib.IOError.CANCELLED)) {
+                                    critical ("Unable to open shutdown dialog: %s", e.message);
+                                }
+                            }
+                        });
+                    } else {
+                        show_dialog (Widgets.EndSessionDialogType.RESTART);
+                    }
+
                     return Gdk.EVENT_STOP;
                 }
 
@@ -147,7 +166,23 @@ public class Session.Indicator : Wingpanel.Indicator {
                 }
             });
 
-            shutdown.clicked.connect (() => show_dialog (Widgets.EndSessionDialogType.RESTART));
+            shutdown.clicked.connect (() => {
+                close ();
+
+                if (server_type == Wingpanel.IndicatorManager.ServerType.SESSION) {
+                    session_interface.reboot.begin ((obj, res) => {
+                        try {
+                            session_interface.reboot.end (res);
+                        } catch (Error e) {
+                            if (!(e is GLib.IOError.CANCELLED)) {
+                                critical ("Unable to open shutdown dialog: %s", e.message);
+                            }
+                        }
+                    });
+                } else {
+                    show_dialog (Widgets.EndSessionDialogType.RESTART);
+                }
+            });
 
             suspend.clicked.connect (() => {
                 close ();
@@ -159,7 +194,17 @@ public class Session.Indicator : Wingpanel.Indicator {
                 }
             });
 
-            log_out.clicked.connect (() => show_dialog (Widgets.EndSessionDialogType.LOGOUT));
+            log_out.clicked.connect (() => {
+                session_interface.logout.begin (0, (obj, res) => {
+                    try {
+                        session_interface.logout.end (res);
+                    } catch (Error e) {
+                        if (!(e is GLib.IOError.CANCELLED)) {
+                            warning ("Unable to open logout dialog: %s", e.message);
+                        }
+                    }
+                });
+            });
 
             lock_screen.clicked.connect (() => {
                 close ();
@@ -190,6 +235,18 @@ public class Session.Indicator : Wingpanel.Indicator {
                 warning ("Unable to connect to lock interface: %s", e.message);
                 lock_screen.set_sensitive (false);
             }
+
+            try {
+                session_interface = Bus.get_proxy_sync (BusType.SESSION, "org.gnome.SessionManager", "/org/gnome/SessionManager");
+            } catch (IOError e) {
+                critical ("Unable to connect to GNOME session interface: %s", e.message);
+            }
+        } else {
+            try {
+                system_interface = Bus.get_proxy_sync (BusType.SYSTEM, "org.freedesktop.login1", "/org/freedesktop/login1");
+            } catch (IOError e) {
+                critical ("Unable to connect to the login interface: %s", e.message);
+            }
         }
     }
 
@@ -214,8 +271,46 @@ public class Session.Indicator : Wingpanel.Indicator {
             }
         }
 
+        unowned EndSessionDialogServer server = EndSessionDialogServer.get_default ();
+
         current_dialog = new Widgets.EndSessionDialog (type);
-        current_dialog.destroy.connect (() => current_dialog = null);
+        current_dialog.destroy.connect (() => {
+            server.closed ();
+            current_dialog = null;
+        });
+
+        current_dialog.cancelled.connect (() => {
+            server.canceled ();
+        });
+
+        current_dialog.logout.connect (() => {
+            server.confirmed_logout ();
+        });
+
+        current_dialog.shutdown.connect (() => {
+            if (server_type == Wingpanel.IndicatorManager.ServerType.SESSION) {
+                server.confirmed_shutdown ();
+            } else {
+                try {
+                    system_interface.power_off (false);
+                } catch (Error e) {
+                    warning ("Unable to shutdown: %s", e.message);
+                }
+            }
+        });
+
+        current_dialog.reboot.connect (() => {
+            if (server_type == Wingpanel.IndicatorManager.ServerType.SESSION) {
+                server.confirmed_reboot ();
+            } else {
+                try {
+                    system_interface.reboot (false);
+                } catch (Error e) {
+                    warning ("Unable to reboot: %s", e.message);
+                }
+            }
+        });
+
         current_dialog.set_transient_for (indicator_icon.get_toplevel () as Gtk.Window);
         current_dialog.show_all ();
     }

--- a/src/Services/DbusInterfaces.vala
+++ b/src/Services/DbusInterfaces.vala
@@ -23,15 +23,17 @@ struct UserInfo {
     ObjectPath? user_object;
 }
 
+[DBus (name = "org.gnome.SessionManager")]
+interface SessionInterface : Object {
+    public abstract async void logout (uint type) throws GLib.Error;
+    public abstract async void reboot () throws GLib.Error;
+    public abstract async void shutdown () throws GLib.Error;
+}
+
 /* Power and system control */
 [DBus (name = "org.freedesktop.ScreenSaver")]
 interface LockInterface : Object {
     public abstract void lock () throws GLib.Error;
-}
-
-[DBus (name = "org.freedesktop.login1.User")]
-interface LogoutInterface : Object {
-    public abstract void terminate () throws GLib.Error;
 }
 
 [DBus (name = "org.freedesktop.login1.Manager")]

--- a/src/Widgets/EndSessionDialog.vala
+++ b/src/Widgets/EndSessionDialog.vala
@@ -29,8 +29,10 @@ public enum Session.Widgets.EndSessionDialogType {
 }
 
 public class Session.Widgets.EndSessionDialog : Gtk.Window {
-    private static LogoutInterface? logout_interface;
-    private static SystemInterface? system_interface;
+    public signal void reboot ();
+    public signal void shutdown ();
+    public signal void logout ();
+    public signal void cancelled ();
 
     public EndSessionDialogType dialog_type { get; construct; }
 
@@ -39,18 +41,6 @@ public class Session.Widgets.EndSessionDialog : Gtk.Window {
     }
 
     construct {
-        var server = EndSessionDialogServer.get_default ();
-
-        try {
-            if (dialog_type == Session.Widgets.EndSessionDialogType.LOGOUT && logout_interface == null) {
-                logout_interface = Bus.get_proxy_sync (BusType.SYSTEM, "org.freedesktop.login1", "/org/freedesktop/login1/user/self");
-            } else if (system_interface == null) {
-                system_interface = Bus.get_proxy_sync (BusType.SYSTEM, "org.freedesktop.login1", "/org/freedesktop/login1");
-            }
-        } catch (GLib.Error e) {
-            critical ("Unable to connect to login1: %s", e.message);
-        }
-
         string icon_name, heading_text, button_text, content_text;
 
         switch (dialog_type) {
@@ -105,14 +95,7 @@ public class Session.Widgets.EndSessionDialog : Gtk.Window {
         if (dialog_type == EndSessionDialogType.RESTART) {
             var confirm_restart = new Gtk.Button.with_label (_("Restart"));
             confirm_restart.clicked.connect (() => {
-                try {
-                    server.confirmed_reboot ();
-                    system_interface.reboot (false);
-                } catch (GLib.Error e) {
-                    warning ("Unable to reboot: %s", e.message);
-                }
-
-                server.closed ();
+                reboot ();
                 destroy ();
             });
 
@@ -151,8 +134,7 @@ public class Session.Widgets.EndSessionDialog : Gtk.Window {
 
         var cancel_action = new SimpleAction ("cancel", null);
         cancel_action.activate.connect (() => {
-            server.canceled ();
-            server.closed ();
+            cancelled ();
             destroy ();
         });
 
@@ -170,22 +152,11 @@ public class Session.Widgets.EndSessionDialog : Gtk.Window {
 
         confirm.clicked.connect (() => {
             if (dialog_type == EndSessionDialogType.RESTART || dialog_type == EndSessionDialogType.SHUTDOWN) {
-                try {
-                    server.confirmed_shutdown ();
-                    system_interface.power_off (false);
-                } catch (GLib.Error e) {
-                    warning ("Unable to shutdown: %s", e.message);
-                }
+                shutdown ();
             } else {
-                try {
-                    server.confirmed_logout ();
-                    logout_interface.terminate ();
-                } catch (GLib.Error e) {
-                    warning ("Unable to logout: %s", e.message);
-                }
+                logout ();
             }
 
-            server.closed ();
             destroy ();
         });
     }


### PR DESCRIPTION
Previously the `EndSessionDialog` class handled all the logic for which DBus interfaces to call when a logout/reboot/shutdown action was confirmed.

It was calling methods like `terminate` and `reboot` on `org.freedesktop.login1`, which is fine if you don't have an active session (i.e. you're in greeter mode). But when we're in a session, it's a lot cleaner to ask `gnome-session` to do these things for us as it handles talking to all of the active applications and asking them to close cleanly, rather than just killing them.

So I've moved that logic out of the dialog and it's only UI code that remains. Now, when we're in an active session and a logout/shutdown button is pressed, we call the logout/reboot/shutdown methods on `org.gnome.SessionManager`, which in turn spawns the `EndSessionDialog` via DBus and we either confirm or cancel that request depending on the outcome of the dialog.

If we're not in an active session, we spawn the dialog manually and then call the `org.freedesktop.login1` methods as before.

I found that logging out on our focal builds was really hit and miss. Most of the time you'd just end up sat looking at your wallpaper with no wingpanel/plank etc and never get kicked back to the greeter. Then you'd have to power cycle the machine to get it working again. This fixes that.

It also hopefully closes applications in the session a bit more cleanly, so hopefully we'll see a few more things saving their state a bit better.