### PR TITLE
Use GNOME interface for screen lock option

### DIFF
--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -236,7 +236,7 @@ public class Session.Indicator : Wingpanel.Indicator {
 
         if (server_type == Wingpanel.IndicatorManager.ServerType.SESSION) {
             try {
-                lock_interface = Bus.get_proxy_sync (BusType.SESSION, "org.freedesktop.ScreenSaver", "/org/freedesktop/ScreenSaver");
+                lock_interface = Bus.get_proxy_sync (BusType.SESSION, "org.gnome.ScreenSaver", "/org/gnome/ScreenSaver");
             } catch (IOError e) {
                 warning ("Unable to connect to lock interface: %s", e.message);
                 lock_screen.set_sensitive (false);

--- a/src/Services/DbusInterfaces.vala
+++ b/src/Services/DbusInterfaces.vala
@@ -31,7 +31,7 @@ interface SessionInterface : Object {
 }
 
 /* Power and system control */
-[DBus (name = "org.freedesktop.ScreenSaver")]
+[DBus (name = "org.gnome.ScreenSaver")]
 interface LockInterface : Object {
     public abstract void lock () throws GLib.Error;
 }


### PR DESCRIPTION
Fixes #142 

The GSD proxy that now owns the `org.freedesktop.ScreenSaver` bus does not support proxying the `lock` method to the underlying screen locker in Gala, so we need to talk to it directly now that we implement the GNOME screensaver interface in Gala.

This only affects explicitly clicking on the "lock" option in the menu of this indicator. 