### PR TITLE
Session indicator tooltip

### DIFF
--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -158,6 +158,7 @@ public class Session.Indicator : Wingpanel.Indicator {
             }
 
             manager.close.connect (() => close ());
+            manager.update_tooltip.connect (() => update_tooltip ());
 
             user_settings.clicked.connect (() => {
                 close ();

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -57,6 +57,9 @@ public class Session.Indicator : Wingpanel.Indicator {
     public override Gtk.Widget get_display_widget () {
         if (indicator_icon == null) {
             indicator_icon = new Wingpanel.Widgets.OverlayIcon (ICON_NAME);
+
+            update_tooltip ();
+
             indicator_icon.button_press_event.connect ((e) => {
                 if (e.button == Gdk.BUTTON_MIDDLE) {
                     if (session_interface == null) {
@@ -319,6 +322,25 @@ public class Session.Indicator : Wingpanel.Indicator {
 
         current_dialog.set_transient_for (indicator_icon.get_toplevel () as Gtk.Window);
         current_dialog.show_all ();
+    }
+
+    private void update_tooltip () {
+        string real_name = "Loong Yeat";
+        int other_users = 2;
+
+        string description = _("Logged in as %s".printf (real_name));
+        string users_logged_in = "";
+
+        if (other_users > 0) {
+            users_logged_in = _(", %i other %s logged in".printf (
+                other_users,
+                ngettext ("user", "users", other_users)
+            ));
+        }
+
+        string accel_label = Granite.TOOLTIP_SECONDARY_TEXT_MARKUP.printf (_("Middle-click to prompt to shut down"));
+
+        indicator_icon.tooltip_markup = "%s%s\n%s".printf (description, users_logged_in, accel_label);
     }
 }
 

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -325,8 +325,13 @@ public class Session.Indicator : Wingpanel.Indicator {
     }
 
     private void update_tooltip () {
-        string real_name = "Loong Yeat";
-        int other_users = 2;
+        manager = new Session.Services.UserManager (new Wingpanel.Widgets.Separator ());
+
+        string real_name = manager.get_active_real_name ();
+        int other_users = manager.get_number_of_active_users () - 1;
+
+        debug ("Real name: %s".printf (real_name));
+        debug ("Number of other users: %i".printf (other_users));
 
         string description = _("Logged in as %s".printf (real_name));
         string users_logged_in = "";

--- a/src/Services/UserManager.vala
+++ b/src/Services/UserManager.vala
@@ -134,6 +134,10 @@ public class Session.Services.UserManager : Object {
         manager.user_added.connect (add_user);
         manager.user_removed.connect (remove_user);
         manager.user_is_logged_in_changed.connect (update_user);
+        manager.user_changed.connect (() => {
+            debug ("User changed");
+            update_tooltip ();
+        });
 
         manager.notify["is-loaded"].connect (() => {
             init_users ();
@@ -219,7 +223,6 @@ public class Session.Services.UserManager : Object {
         }
 
         userbox.update_state ();
-        update_tooltip ();
     }
 
     public void update_all () {

--- a/src/Services/UserManager.vala
+++ b/src/Services/UserManager.vala
@@ -134,9 +134,6 @@ public class Session.Services.UserManager : Object {
         manager.user_added.connect (add_user);
         manager.user_removed.connect (remove_user);
         manager.user_is_logged_in_changed.connect (update_user);
-        manager.user_changed.connect (() => {
-            update_tooltip ();
-        });
 
         manager.notify["is-loaded"].connect (() => {
             init_users ();

--- a/src/Services/UserManager.vala
+++ b/src/Services/UserManager.vala
@@ -36,6 +36,7 @@ public enum UserState {
 
 public class Session.Services.UserManager : Object {
     public signal void close ();
+    public signal void update_tooltip ();
 
     public Session.Widgets.UserListBox user_grid { get; private set; }
     public Wingpanel.Widgets.Separator users_separator { get; construct; }
@@ -179,6 +180,8 @@ public class Session.Services.UserManager : Object {
         foreach (Act.User user in manager.list_users ()) {
             add_user (user);
         }
+
+        update_tooltip ();
     }
 
     private void add_user (Act.User? user) {
@@ -192,6 +195,8 @@ public class Session.Services.UserManager : Object {
         user_grid.add (user_boxes[uid]);
 
         users_separator.visible = true;
+
+        update_tooltip ();
     }
 
     private void remove_user (Act.User user) {
@@ -203,6 +208,8 @@ public class Session.Services.UserManager : Object {
 
         user_boxes.unset (uid);
         user_grid.remove (userbox);
+
+        update_tooltip ();
     }
 
     private void update_user (Act.User user) {

--- a/src/Services/UserManager.vala
+++ b/src/Services/UserManager.vala
@@ -219,6 +219,7 @@ public class Session.Services.UserManager : Object {
         }
 
         userbox.update_state ();
+        update_tooltip ();
     }
 
     public void update_all () {

--- a/src/Services/UserManager.vala
+++ b/src/Services/UserManager.vala
@@ -232,4 +232,28 @@ public class Session.Services.UserManager : Object {
 
         users_separator.visible = true;
     }
+
+    public string get_active_real_name () {
+        foreach (Act.User user in manager.list_users ()) {
+            if (get_user_state (user.uid) == UserState.ACTIVE) {
+                return user.real_name;
+            }
+        }
+
+        return "Unknown";
+    }
+
+    public int get_number_of_active_users () {
+        int number_of_active_users = 0;
+
+        foreach (Act.User user in manager.list_users ()) {
+            var state = get_user_state (user.uid);
+
+            if (state == UserState.ONLINE || state == UserState.ACTIVE) {
+                number_of_active_users++;
+            }
+        }
+
+        return number_of_active_users;
+    }
 }

--- a/src/Services/UserManager.vala
+++ b/src/Services/UserManager.vala
@@ -135,7 +135,6 @@ public class Session.Services.UserManager : Object {
         manager.user_removed.connect (remove_user);
         manager.user_is_logged_in_changed.connect (update_user);
         manager.user_changed.connect (() => {
-            debug ("User changed");
             update_tooltip ();
         });
 


### PR DESCRIPTION
Closes #143.

Demo:

![screen-capture-_2_](https://user-images.githubusercontent.com/31680656/102722138-10907980-433a-11eb-9279-a7a7a98bbd55.gif)

Note: New user does not show in popover when new user is created (#146). This occured on `wingpanel-indicator-session` on master but may be a localised issue for me since I messed around with `AccountsManager`.