### PR TITLE
l10n: Correctly setup the locales

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -18,7 +18,8 @@ wingpanel_dep = dependency('wingpanel')
 wingpanel_indicatorsdir = wingpanel_dep.get_pkgconfig_variable('indicatorsdir', define_variable: ['libdir', libdir])
 
 config_data = configuration_data()
-config_data.set('GETTEXT_PACKAGE', meson.project_name())
+config_data.set('GETTEXT_PACKAGE', meson.project_name() + '-indicator')
+config_data.set('LOCALEDIR', join_paths(get_option('prefix'), get_option('localedir')))
 config_vala = configure_file(
     input: 'src/Config.vala.in',
     output: '@BASENAME@',

--- a/src/Config.vala.in
+++ b/src/Config.vala.in
@@ -19,4 +19,5 @@
 
 namespace Session {
     private const string GETTEXT_PACKAGE = "@GETTEXT_PACKAGE@";
+    private const string LOCALEDIR = "@LOCALEDIR@";
 }

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -42,6 +42,9 @@ public class Session.Indicator : Wingpanel.Indicator {
     private static GLib.Settings? keybinding_settings;
 
     public Indicator (Wingpanel.IndicatorManager.ServerType server_type) {
+        GLib.Intl.bindtextdomain (Session.GETTEXT_PACKAGE, Session.LOCALEDIR);
+        GLib.Intl.bind_textdomain_codeset (Session.GETTEXT_PACKAGE, "UTF-8");
+
         Object (code_name: Wingpanel.Indicator.SESSION);
         this.server_type = server_type;
         this.visible = true;


### PR DESCRIPTION
Provides the directory where the locales are actually installed.

We are [packaging this](https://github.com/NixOS/nixpkgs/pull/130380#issuecomment-895720580) in NixOS, and due to NixOS 's special `localedir`, we cannot apply the translations without this patch.

Thanks in advance for reviewing this :-)