### PR TITLE
Only show suspend button if suspend is available

### DIFF
--- a/src/Services/DbusInterfaces.vala
+++ b/src/Services/DbusInterfaces.vala
@@ -43,6 +43,7 @@ interface SystemInterface : Object {
     public abstract void power_off (bool interactive) throws GLib.Error;
 
     public abstract UserInfo[] list_users () throws GLib.Error;
+    public abstract string can_suspend () throws GLib.Error;
 }
 
 [DBus (name = "org.freedesktop.login1.User")]


### PR DESCRIPTION
Also don't bind its visibility to `lock-on-suspend` as that does as I understand it and as it was pointed out by @tintou only affect suspend behavior not lock behavior and therefore doesn't make suspend redundant.

Fixes #178
Fixes #166
Probably fixes #131 